### PR TITLE
Fix DescribeSObjectResult to match actual return value from SF API

### DIFF
--- a/describe-result.d.ts
+++ b/describe-result.d.ts
@@ -60,6 +60,11 @@ export interface ChildRelationship {
     restrictedDelete: boolean;
 }
 
+export interface DefaultValueWithType {
+    $: Record<string, string>;
+    _: string;
+}
+
 export interface Field {
     aggregatable: boolean;
     autonumber: boolean;
@@ -72,7 +77,7 @@ export interface Field {
     controllerName?: maybe<string>;
     createable: boolean;
     custom: boolean;
-    defaultValue?: maybe<string | boolean>;
+    defaultValue?: maybe<string | boolean | number | DefaultValueWithType>;
     defaultValueFormula?: maybe<string>;
     defaultedOnCreate: boolean;
     dependentPicklist: boolean;


### PR DESCRIPTION
When using the describeSObjects API the default value returns as an object
with a type and a value under $ and _ for some undocumented reason