### PR TITLE
Fix to API definition

### DIFF
--- a/describe-result.d.ts
+++ b/describe-result.d.ts
@@ -67,7 +67,7 @@ export interface DefaultValueWithType {
 
 export interface Field {
     aggregatable: boolean;
-    autonumber: boolean;
+    autoNumber: boolean;
     byteLength: number;
     calculated: boolean;
     calculatedFormula?: maybe<string>;


### PR DESCRIPTION
auto number boolean field is not aligned with what is returned from the API ("autoNumber"), hence it is always undefined.